### PR TITLE
Fix import path for go-gopher

### DIFF
--- a/node.js/2019-06-14.txt
+++ b/node.js/2019-06-14.txt
@@ -1438,7 +1438,7 @@
 {"nick":"sembiance","message":"ljharb: your best bet is to time travel to the 80's though","date":"2019-06-14T18:54:39.203Z","type":"message"}
 {"nick":"joepie91[m]","message":"the real question here is","date":"2019-06-14T18:54:52.669Z","type":"message"}
 {"nick":"joepie91[m]","message":"is there a gopher client written in Go yet","date":"2019-06-14T18:54:59.734Z","type":"message"}
-{"nick":"sembiance","message":"there is a library: https://github.com/prologic/go-gopher","date":"2019-06-14T18:55:47.206Z","type":"message"}
+{"nick":"sembiance","message":"there is a library: https://git.mills.io/prologic/go-gopher","date":"2019-06-14T18:55:47.206Z","type":"message"}
 {"nick":"entry_lvl_dev","reason":"Quit: WeeChat 2.5","date":"2019-06-14T18:56:07.748Z","type":"quit"}
 {"nick":"ljharb","message":"sembiance: nah i had a great graphical gopher client on my mac in the 90s","date":"2019-06-14T18:56:38.836Z","type":"message"}
 {"nick":"ljharb","message":"\"go-gopher\" is the dumbest missed naming opportunity","date":"2019-06-14T18:56:50.975Z","type":"message"}


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/go-gopher](https://git.mills.io/prologic/go-gopher).

For details on why see: https://github.com/prologic

Thank you! 🙇